### PR TITLE
- fixed: Issue #1 - Line numbers disappear after reloading a file

### DIFF
--- a/src/Main.pas
+++ b/src/Main.pas
@@ -382,6 +382,9 @@ begin
   if FBlockEvents then exit;
 
   CheckTextChanges();
+
+  if GetLineCount(GetCurrentViewIdx()) = 1 then
+    RemoveCurrentBufferFromCatalog();
 end;
 
 


### PR DESCRIPTION
Reloading a file is done by deleting all lines of a document and inserting the lines of the reloaded file afterwards. Then an `NPPN_BUFFERACTIVATED` event is triggered.

In the event handler for the Scintilla event  `SCN_MODIFIED` (modificationType `SC_MOD_DELETETEXT`) we can check if the number of lines of the current document is 1. In this case we can delete the key-value pair addressed by the current buffer ID from our book keeping dictionary. When the `NPPN_BUFFERACTIVATED` event is handled that results in a renumbering of the document's lines.