### PR TITLE
- fixed: Issue #9 - Still problems with missing line numbers when changing height of Notepad++ window

### DIFF
--- a/src/Main.pas
+++ b/src/Main.pas
@@ -410,12 +410,12 @@ begin
     // update line numbers else advance to next view
     case CurViewIdx of
       MAIN_VIEW:
-        if CurLineCnt > FLineCntMainView
+        if CurLineCnt <> FLineCntMainView
           then FLineCntMainView := CurLineCnt
           else continue;
-        
+
       SUB_VIEW:
-        if CurLineCnt > FLineCntSubView
+        if CurLineCnt <> FLineCntSubView
           then FLineCntSubView := CurLineCnt
           else continue;
     end;


### PR DESCRIPTION
It is not sufficient to set line numbers only when the height of a Scintilla windows has been **increased**. To do so it would be neccessary to write a managing framwork to maintain an always correct state of the variable which remembers the last known height of the window. This requires too much effort, instead we set line numbers when the current and the last known height of the window is different.

Closes #9 